### PR TITLE
Support Puppet v4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,7 @@
+fixtures:
+  repositories:
+    stdlib:
+      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+      ref: '4.6.0'
+  symlinks:
+    sumo: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Default .gitignore for Ruby
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+
+# Vim
+*.swp
+
+# Eclipse
+.project
+
+# OS X
+.DS_Store
+
+# Puppet
+coverage/
+spec/fixtures/manifests/*
+spec/fixtures/modules/*
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+---
+language: ruby
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.3.1
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+    - PUPPET_GEM_VERSION="~> 4.8.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
+sudo: false
+
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.5.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.7.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.8.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,30 @@
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
+gem 'puppet-lint', '~> 2.0'
+gem 'puppet-lint-absolute_classname-check'
+gem 'puppet-lint-alias-check'
+gem 'puppet-lint-empty_string-check'
+gem 'puppet-lint-file_ensure-check'
+gem 'puppet-lint-file_source_rights-check'
+gem 'puppet-lint-leading_zero-check'
+gem 'puppet-lint-spaceship_operator_without_tag-check'
+gem 'puppet-lint-trailing_comma-check'
+gem 'puppet-lint-undef_in_function-check'
+gem 'puppet-lint-unquoted_string-check'
+gem 'puppet-lint-variable_contains_upcase'
+
+gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
+gem 'metadata-json-lint'             if RUBY_VERSION >= '1.9'

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.relative = true
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
-desc "Validate manifests, templates, and ruby files"
+desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,27 +1,28 @@
 # sumo::conf
 #
-# This class manages the sumo.conf file, which the collector uses to perform 
-# initial setup. 
+# This class manages the sumo.conf file, which the collector uses to perform
+# initial setup.
 #
 define sumo::conf (
-  $accessid = undef,
-  $accesskey = undef,
-  $clobber = undef,
-  $email = undef,
-  $ephemeral = undef,
-  $collectorName = undef,
-  $override = undef,
-  $password = undef,
-  $proxyHost = undef,
-  $proxyNtlmDomain = undef,
-  $proxyPassword = undef,
-  $proxyPort = undef,
-  $proxyUser = undef,
-  $sources = undef,
-  $syncSources = undef,
+  $accessid        = undef,
+  $accesskey       = undef,
+  $clobber         = undef,
+  $email           = undef,
+  $ephemeral       = undef,
+  $collectorname   = undef,
+  $override        = undef,
+  $password        = undef,
+  $proxyhost       = undef,
+  $proxyntlmdomain = undef,
+  $proxypassword   = undef,
+  $proxyport       = undef,
+  $proxyuser       = undef,
+  $sources         = undef,
+  $syncsources     = undef,
 ) {
-  include sumo
-  
+
+  include ::sumo
+
   if ($accessid != undef or $accesskey != undef) and ($email != undef or $password != undef) {
     fail('You must pass either an accessid/accesskey pair or an email/password pair, not both.')
   } elsif (($accessid == undef and $accesskey != undef) or ($accessid != undef and $accesskey == undef)) {
@@ -29,10 +30,10 @@ define sumo::conf (
   } elsif (($email == undef and $password != undef) or ($email != undef and $password == undef)) {
     fail('You must pass both the email and password.')
   }
-  
+
   # The docs aren't clear, but it seems like the config file really wants
   # the syncSources value to end in a slash if it's a directory
-  if( $syncSources != undef) {
+  if( $syncsources != undef) {
     if $::sumo::purge_sumo_sources_d == true {
       $syncsources_purge = true
       $syncsources_recurse = true
@@ -41,7 +42,7 @@ define sumo::conf (
       $syncsources_recurse = undef
     }
 
-    file { $syncSources:
+    file { $syncsources:
       ensure  => 'directory',
       owner   => 'root',
       group   => 'root',
@@ -49,13 +50,13 @@ define sumo::conf (
       purge   => $syncsources_purge,
       recurse => $syncsources_recurse,
     }
-    $syncSourcesWithTrailingSlash = "${syncSources}/"
+    $syncsourceswithtrailingslash = "${syncsources}/"
   } else {
-    $syncSourcesWithTrailingSlash = undef
+    $syncsourceswithtrailingslash = undef
   }
 
   file { $::sumo::params::sumo_service_config:
-    ensure  => present,
+    ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0600',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,21 +3,24 @@
 # This class performs all configuration actions for the collector package.
 #
 class sumo::config {
-  sumo::conf {'sumo.conf':
+
+  include ::sumo::config
+
+  sumo::conf { 'sumo.conf':
     accessid        => $::sumo::accessid,
     accesskey       => $::sumo::accesskey,
     clobber         => $::sumo::clobber,
-    collectorName   => $::sumo::collectorName,
+    collectorname   => $::sumo::collectorname,
     email           => $::sumo::email,
     ephemeral       => $::sumo::ephemeral,
     override        => $::sumo::override,
     password        => $::sumo::password,
-    proxyHost       => $::sumo::proxyHost,
-    proxyNtlmDomain => $::sumo::proxyNtlmDomain,
-    proxyPassword   => $::sumo::proxyPassword,
-    proxyPort       => $::sumo::proxyPort,
-    proxyUser       => $::sumo::proxyUser,
+    proxyhost       => $::sumo::proxyhost,
+    proxyntlmdomain => $::sumo::proxyntlmdomain,
+    proxypassword   => $::sumo::proxypassword,
+    proxyport       => $::sumo::proxyport,
+    proxyuser       => $::sumo::proxyuser,
     sources         => $::sumo::sources,
-    syncSources     => $::sumo::syncSources,
+    syncsources     => $::sumo::syncsources,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,13 +24,13 @@
 #   the same name.
 #
 # [*collectorName*]
-#   The name of the collector. Defaults to the hostname. 
+#   The name of the collector. Defaults to the hostname.
 #
 # [*email*]
 #   Specify the email address of the account to use to authenticate to the
-#   Sumo Logic service. If you use this parameter, you must also pass a 
+#   Sumo Logic service. If you use this parameter, you must also pass a
 #   password, and you must NOT pass accessid or accesskey.
-# 
+#
 # [*ephemeral*]
 #   A boolean indicating whether the collector should be deleted automatically
 #   after being offline for 12 hours.
@@ -76,15 +76,15 @@
 # === Examples
 #
 # A basic example, using username/password and without any sources:
-# 
+#
 # class sumo {
 #   email    => 'user@example.com',
-#   password => 'usersPassword123!', 
+#   password => 'usersPassword123!',
 # }
 #
 #
 # A more advanced example, using a Sumo accessid and with a local file source:
-# 
+#
 # class sumo {
 #   accessid  => 'SumoAccessId',
 #   accesskey => 'SumoAccessKey_123ABC/&!',
@@ -104,24 +104,25 @@
 # Copyright 2016 Peter D. Jorgensen, unless otherwise noted.
 #
 class sumo (
-  $accessid = $::sumo::params::accessid,
-  $accesskey = $::sumo::params::accesskey,
-  $clobber = $::sumo::params::clobber,
-  $collectorName = $::sumo::params::collectorName,
-  $email = $::sumo::params::email,
-  $ephemeral = $::sumo::params::ephemeral,
+  $accessid             = $::sumo::params::accessid,
+  $accesskey            = $::sumo::params::accesskey,
+  $clobber              = $::sumo::params::clobber,
+  $collectorname        = $::sumo::params::collectorname,
+  $email                = $::sumo::params::email,
+  $ephemeral            = $::sumo::params::ephemeral,
   $purge_sumo_sources_d = $::sumo::params::purge_sumo_sources_d,
-  $override = $::sumo::params::override,
-  $password = $::sumo::params::password,
-  $proxyHost = $::sumo::params::proxyHost,
-  $proxyNtlmDomain = $::sumo::params::proxyNtlmDomain,
-  $proxyPassword = $::sumo::params::proxyPassword,
-  $proxyPort = $::sumo::params::proxyPort,
-  $proxyUser = $::sumo::params::proxyUser,
-  $sources = $::sumo::params::sources,
-  $syncSources = $::sumo::params::syncSources,
+  $override             = $::sumo::params::override,
+  $password             = $::sumo::params::password,
+  $proxyhost            = $::sumo::params::proxyhost,
+  $proxyntlmdomain      = $::sumo::params::proxyntlmdomain,
+  $proxypassword        = $::sumo::params::proxypassword,
+  $proxyport            = $::sumo::params::proxyport,
+  $proxyuser            = $::sumo::params::proxyuser,
+  $sources              = $::sumo::params::sources,
+  $syncsources          = $::sumo::params::syncsources,
 ) inherits sumo::params {
-  include sumo::params, sumo::install, sumo::config, sumo::service
+
+  include ::sumo::params, ::sumo::install, ::sumo::config, ::sumo::service
 
   validate_bool($purge_sumo_sources_d)
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,7 @@
 # native package management tool.
 #
 class sumo::install {
+
   package { $::sumo::params::sumo_package_name:
     ensure  => present,
   }

--- a/manifests/localfilesource.pp
+++ b/manifests/localfilesource.pp
@@ -5,30 +5,31 @@
 # that is configured in sumo.conf.
 #
 define sumo::localfilesource (
-  $pathExpression,
-  $ensure = present,
-  $sourceName = $title,
-  $description = undef,
-  $category = undef,
-  $hostName = undef,
-  $timeZone = undef,
-  $automaticDateParsing = undef,
-  $multilineProcessingEnabled = undef,
-  $useAutolineMatching = undef,
-  $manualPrefixRegexp = undef,
-  $forceTimeZone = undef,
-  $defaultDateFormat = undef,
-  $filters = undef,
-  $blacklist = undef,
-  $encoding = undef,
+  $pathexpression,
+  $ensure                     = present,
+  $sourcename                 = $title,
+  $description                = undef,
+  $category                   = undef,
+  $hostname                   = undef,
+  $timezone                   = undef,
+  $automaticdateparsing       = undef,
+  $multilineprocessingenabled = undef,
+  $useautolinematching        = undef,
+  $manualprefixregexp         = undef,
+  $forcetimezone              = undef,
+  $defaultdateformat          = undef,
+  $filters                    = undef,
+  $blacklist                  = undef,
+  $encoding                   = undef,
 ) {
-  include sumo
-  include sumo::params
 
-  $sourceType = 'LocalFile'
-  $syncSources  = $::sumo::syncSources
+  include ::sumo
+  include ::sumo::params
 
-  file { "${syncSources}/${name}.json":
+  $sourcetype = 'LocalFile'
+  $syncsources  = $::sumo::syncsources
+
+  file { "${syncsources}/${name}.json":
     ensure  => $ensure,
     owner   => 'root',
     group   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,36 +3,38 @@
 # Default values for parameters used in the module.
 #
 class sumo::params {
+
   case $::osfamily {
     'RedHat': {
       $sumo_package_name   = 'SumoCollector'
       $sumo_service_config  = '/etc/sumo.conf'
       $sumo_service_name  = 'collector'
-      $syncSources    = '/etc/sumo.sources.d'
+      $syncsources    = '/etc/sumo.sources.d'
     }
     'Debian': {
       $sumo_package_name   = 'SumoCollector'
       $sumo_service_config  = '/etc/sumo.conf'
       $sumo_service_name  = 'collector'
-      $syncSources    = '/etc/sumo.sources.d'
+      $syncsources    = '/etc/sumo.sources.d'
     }
     default: {
       fail("Module pjorg-sumo does not support osfamily: ${::osfamily}")
     }
   }
+
   $accessid = undef
   $accesskey = undef
   $clobber = undef
-  $collectorName = undef
+  $collectorname = undef
   $email = undef
   $ephemeral = undef
   $purge_sumo_sources_d = false
   $override = undef
   $password = undef
-  $proxyHost = undef
-  $proxyNtlmDomain = undef
-  $proxyPassword = undef
-  $proxyPort = undef
-  $proxyUser = undef
+  $proxyhost = undef
+  $proxyntlmdomain = undef
+  $proxypassword = undef
+  $proxyport = undef
+  $proxyuser = undef
   $sources = undef
 }

--- a/manifests/remotefilesource.pp
+++ b/manifests/remotefilesource.pp
@@ -5,49 +5,50 @@
 # that is configured in sumo.conf.
 #
 define sumo::remotefilesource (
-  $remotePath,
-  $remoteHosts,
-  $remotePort,
-  $remoteUser,
-  $authMethod,
-  $ensure = present,
-  $sourceName = $title,
-  $description = undef,
-  $category = undef,
-  $hostName = undef,
-  $timeZone = undef,
-  $automaticDateParsing = undef,
-  $multilineProcessingEnabled = undef,
-  $useAutolineMatching = undef,
-  $manualPrefixRegexp = undef,
-  $forceTimeZone = undef,
-  $defaultDateFormat = undef,
-  $filters = undef,
-  $blacklist = undef,
-  $remotePassword = undef,
-  $keyPath = undef,
-  $keyPassword = undef,
+  $remotepath,
+  $remotehosts,
+  $remoteport,
+  $remoteuser,
+  $authmethod,
+  $ensure                     = present,
+  $sourcename                 = $title,
+  $description                = undef,
+  $category                   = undef,
+  $hostname                   = undef,
+  $timezone                   = undef,
+  $automaticdateparsing       = undef,
+  $multilineprocessingenabled = undef,
+  $useautolinematching        = undef,
+  $manualprefixregexp         = undef,
+  $forcetimezone              = undef,
+  $defaultdateformat          = undef,
+  $filters                    = undef,
+  $blacklist                  = undef,
+  $remotepassword             = undef,
+  $keypath                    = undef,
+  $keypassword                = undef,
 ) {
-  include sumo
 
-  $sourceType = 'RemoteFile'
-  $syncSources  = $::sumo::syncSources
+  include ::sumo
 
-  if (downcase($authMethod) == 'password') {
-    if ($remotePassword == undef) {
+  $sourcetype = 'RemoteFile'
+  $syncsources  = $::sumo::syncsources
+
+  if (downcase($authmethod) == 'password') {
+    if ($remotepassword == undef) {
       fail('To use password authentication for a remote file source, you must pass a value to remotePassword.')
-    } elsif ($keyPath != undef or $keyPassword != undef) {
+    } elsif ($keypath != undef or $keypassword != undef) {
       warn('If you are using password authentication for a remote file source, do not pass a keyPath or keyPassword.')
     }
-  } elsif (downcase($authMethod) == 'key') {
-    if ($keyPath == undef) {
+  } elsif (downcase($authmethod) == 'key') {
+    if ($keypath == undef) {
       fail('To use key authentication for a remote file source, you must set the path to the key in keyPath.')
-    } elsif ($remotePassword != undef) {
+    } elsif ($remotepassword != undef) {
       warn('If you are using key authentication for a remote file source, do not pass a remotePassword.')
     }
   }
 
-  file { "${syncSources}/${name}.json":
+  file { "${syncsources}/${name}.json":
     ensure  => $ensure,
     owner   => 'root',
     group   => 'root',
@@ -56,4 +57,3 @@ define sumo::remotefilesource (
     notify  => Service[$::sumo::params::sumo_service_name],
   }
 }
-

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,9 @@
 # Controls the desired state of the collector service.
 #
 class sumo::service {
-  include sumo
+
+  include ::sumo
+
   service { $::sumo::params::sumo_service_name:
     ensure     => running,
     hasstatus  => true,

--- a/manifests/syslogsource.pp
+++ b/manifests/syslogsource.pp
@@ -7,26 +7,27 @@
 define sumo::syslogsource (
   $protocol,
   $port,
-  $ensure = present,
-  $sourceName = $title,
-  $description = undef,
-  $category = undef,
-  $hostName = undef,
-  $timeZone = undef,
-  $automaticDateParsing = undef,
-  $multilineProcessingEnabled = undef,
-  $useAutolineMatching = undef,
-  $manualPrefixRegexp = undef,
-  $forceTimeZone = undef,
-  $defaultDateFormat = undef,
-  $filters = undef,
+  $ensure                     = present,
+  $sourcename                 = $title,
+  $description                = undef,
+  $category                   = undef,
+  $hostname                   = undef,
+  $timezone                   = undef,
+  $automaticdateparsing       = undef,
+  $multilineprocessingenabled = undef,
+  $useautolinematching        = undef,
+  $manualprefixregexp         = undef,
+  $forcetimezone              = undef,
+  $defaultdateformat          = undef,
+  $filters                    = undef,
 ) {
-  include sumo
 
-  $sourceType = 'Syslog'
-  $syncSources  = $::sumo::syncSources
+  include ::sumo
 
-  file { "${syncSources}/${name}.json":
+  $sourcetype = 'Syslog'
+  $syncsources  = $::sumo::syncsources
+
+  file { "${syncsources}/${name}.json":
     ensure  => $ensure,
     owner   => 'root',
     group   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -8,19 +8,39 @@
   "project_page": "https://github.com/pjorg/pjorg-puppet-sumo/wiki",
   "issues_url": "https://github.com/pjorg/pjorg-puppet-sumo/issues",
   "tags": ["sumologic","logs"],
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_range":">= 4.6.0 < 6.0.0" }
+  ],
+  "requirements": [
+    {"name":"puppet","version_requirement":">= 3.0.0 < 5.0.0" }
+  ],
   "operatingsystem_support": [
     {
-      "operatingsystem":"RedHat",
-      "operatingsystemrelease":[ "6.0" ]
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "6"
+      ]
     },
     {
       "operatingsystem":"Debian"
-    }
-  ],
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_range": ">= 1.0.0 < 5.0.0"
     }
   ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,17 @@
-dir = File.expand_path(File.dirname(__FILE__))
-$LOAD_PATH.unshift File.join(dir, 'lib')
+require 'puppetlabs_spec_helper/module_spec_helper'
 
-require 'mocha'
-require 'puppet'
-require 'rspec'
-require 'spec/autorun'
-
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
-end
-
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
+RSpec.configure do |config|
+  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  config.before :each do
+    # Ensure that we don't accidentally cache facts and environment between
+    # test cases.  This requires each example group to explicitly load the
+    # facts being exercised with something like
+    # Facter.collection.loader.load(:ipaddress)
+    Facter.clear
+    Facter.clear_messages
+  end
+  config.default_facts = {
+    :environment => 'rp_env',
+    :osfamily    => 'Debian',
+  }
 end

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -9,4 +9,4 @@
 # Learn more about module testing here:
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
-include sumo
+include ::sumo


### PR DESCRIPTION
* Explicitly test against supported matrix of Puppet and Ruby versions.
* Support Puppet v3 and v4.
* Support Ruby versions 1.8.7, 1.9.3, 2.0.0, 2.1.0 and 2.3.1.