### PR TITLE
Updates to allow overriding of agent config file and minor usage comments. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A basic example, using username/password and without any sources:
 
 ~~~puppet
 node mynode.lab.local {
-  class sumo {
+  class { 'sumo':
     email    => 'user@example.com',
     password => 'usersPassword123!', 
   }
@@ -79,14 +79,14 @@ A more advanced example, using a Sumo accessid and with a local file source:
 
 ~~~puppet
 node mynode.lab.local {
-  class sumo {
+  class { 'sumo':
     accessid  => 'SumoAccessId',
     accesskey => 'SumoAccessKey_123ABC/&!',
   }
 
   sumo::localfilesource { 'messages':
-    sourceName => 'message_log'
-    pathExpression => '/var/log/messages',
+    sourcename     => 'message_log'
+    pathexpression => '/var/log/messages',
   }
 }
 ~~~  

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -20,6 +20,7 @@ define sumo::conf (
   $sources                   = undef,
   $syncsources               = undef,
   $syncsourceswithsinglejson = undef,
+  $serviceconfig             = undef,
 ) {
 
   include ::sumo
@@ -63,7 +64,7 @@ define sumo::conf (
       $syncsourceswithtrailingslash = "${syncsources}/"
   }
 
-  file { $::sumo::params::sumo_service_config:
+  file { $serviceconfig:
     ensure  => file,
     owner   => 'root',
     group   => 'root',

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -17,10 +17,10 @@ define sumo::conf (
   $proxypassword             = undef,
   $proxyport                 = undef,
   $proxyuser                 = undef,
+  $serviceconfig             = undef,
   $sources                   = undef,
   $syncsources               = undef,
   $syncsourceswithsinglejson = undef,
-  $serviceconfig             = undef,
 ) {
 
   include ::sumo

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,9 +20,9 @@ class sumo::config {
     proxypassword             => $::sumo::proxypassword,
     proxyport                 => $::sumo::proxyport,
     proxyuser                 => $::sumo::proxyuser,
+    serviceconfig             => $::sumo::serviceconfig,
     sources                   => $::sumo::sources,
     syncsources               => $::sumo::syncsources,
     syncsourceswithsinglejson => $::sumo::syncsourceswithsinglejson,
-    serviceconfig             => $::sumo::serviceconfig
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,5 +23,6 @@ class sumo::config {
     sources                   => $::sumo::sources,
     syncsources               => $::sumo::syncsources,
     syncsourceswithsinglejson => $::sumo::syncsourceswithsinglejson,
+    serviceconfig             => $::sumo::serviceconfig
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,8 @@
 # [*proxyuser*]
 #   The username to use when authenticating to a proxy.
 #
+# [*serviceconfig]
+#   Set the filename used for agent configuration.
 # [*sources*]
 #   Path to JSON file that contains Source configuration.
 #
@@ -77,7 +79,7 @@
 #
 # A basic example, using username/password and without any sources:
 #
-# class sumo {
+# class { 'sumo':
 #   email    => 'user@example.com',
 #   password => 'usersPassword123!',
 # }
@@ -85,7 +87,7 @@
 #
 # A more advanced example, using a Sumo accessid and with a local file source:
 #
-# class sumo {
+# class { 'sumo':
 #   accessid  => 'SumoAccessId',
 #   accesskey => 'SumoAccessKey_123ABC/&!',
 # }
@@ -118,10 +120,10 @@ class sumo (
   $proxypassword              = $::sumo::params::proxypassword,
   $proxyport                  = $::sumo::params::proxyport,
   $proxyuser                  = $::sumo::params::proxyuser,
+  $serviceconfig              = $::sumo::params::sumo_service_config,
   $sources                    = $::sumo::params::sources,
   $syncsources                = $::sumo::params::syncsources,
   $syncsourceswithsinglejson  = $::sumo::params::syncsourceswithsinglejson,
-  $serviceconfig              = $::sumo::params::sumo_service_config,
 ) inherits sumo::params {
 
   include ::sumo::params, ::sumo::install, ::sumo::config, ::sumo::service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,6 +121,7 @@ class sumo (
   $sources                    = $::sumo::params::sources,
   $syncsources                = $::sumo::params::syncsources,
   $syncsourceswithsinglejson  = $::sumo::params::syncsourceswithsinglejson,
+  $serviceconfig              = $::sumo::params::sumo_service_config,
 ) inherits sumo::params {
 
   include ::sumo::params, ::sumo::install, ::sumo::config, ::sumo::service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@
 #
 # [*serviceconfig]
 #   Set the filename used for agent configuration.
+#
 # [*sources*]
 #   Path to JSON file that contains Source configuration.
 #
@@ -91,6 +92,7 @@
 #   accessid  => 'SumoAccessId',
 #   accesskey => 'SumoAccessKey_123ABC/&!',
 # }
+#
 # sumo::localfilesource { 'messages':
 #   sourcename => 'message_log'
 #   pathexpression => '/var/log/messages',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class sumo::params {
   $proxypassword = undef
   $proxyport = undef
   $proxyuser = undef
+  $serviceconfig = undef
   $sources = undef
   $syncsourceswithsinglejson = undef
 }


### PR DESCRIPTION
I updated this to allow overriding the the source config file for sumo agent.

This is so one could use `user.properties` vs. sumo.conf.

Also made a few other changes to README. 

Tested on Puppet 5 and hiera.

Thanks!!